### PR TITLE
Remove --quiet option and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,28 +121,6 @@ CORE SYNTHESIS OPTIONS
 ```
 
 ## Warnings & Notes
------------------------------------------------------------------
-
-USAGE
-pdf2mp3 INPUT_PDF [OUTPUT_MP3] [OPTIONS]
-
-FILES (POSITIONAL)
-    INPUT_PDF                Path to the source PDF file.
-    OUTPUT_MP3               Optional destination file.
-                             Defaults to input pdf basename with “.mp3” in current working directory.
-
-CORE SYNTHESIS OPTIONS
-  -l, --lang TEXT            Target language code (e.g., 'a' for American English, 'b' for British English).
-                             Refer to README.md for the full list of supported codes.
-                             Default: 'b' (British English)
-  -v, --voice TEXT           Voice preset. Refer to README.md for available voices.
-                             Default: bf_emma
-  -s, --speed FLOAT          Speaking-rate multiplier (0.5 – 2.0).
-                             Default: 0.8
-... (other options) ...
-```
-
-## Warnings & Notes
 *   The application uses the `hexgrad/Kokoro-82M` model by default.
 *   Some PyTorch warnings (e.g., related to RNN dropout) may appear during execution; these are generally safe and originate from the underlying TTS library.
 

--- a/src/pdf2mp3/cli.py
+++ b/src/pdf2mp3/cli.py
@@ -118,11 +118,6 @@ def main():
     # --- Miscellaneous Options ---
     misc_group = parser.add_argument_group("MISCELLANEOUS OPTIONS")
     misc_group.add_argument(
-        "-q", "--quiet",
-        action="store_true",
-        help="Suppress most non-error console output. Progress bar is also disabled."
-    )
-    misc_group.add_argument(
         "--version",
         action="version",
         version=f"%(prog)s {package_version}",
@@ -155,8 +150,6 @@ def main():
 
     # Adjust show_progress if quiet mode is enabled
     show_progress_actual = args.show_progress
-    if args.quiet:
-        show_progress_actual = False # Quiet mode implies no progress bar
 
     # --- Call Core Conversion Logic ---
     try:

--- a/tests/test_cli_unittest.py
+++ b/tests/test_cli_unittest.py
@@ -144,16 +144,6 @@ class TestCLI(unittest.TestCase):
         self.assertEqual(kwargs['output_mp3_path'], expected_output_path)
 
     @patch("pdf2mp3.cli.core.convert_pdf_to_mp3")
-    def test_cli_quiet_mode(self, mock_convert):
-        """Test that quiet mode disables progress."""
-        with patch.object(sys, 'argv', ['pdf2mp3', str(self.dummy_pdf_path), '--quiet']):
-            cli_main()
-
-        mock_convert.assert_called_once()
-        args, kwargs = mock_convert.call_args
-        self.assertFalse(kwargs['show_progress'])
-
-    @patch("pdf2mp3.cli.core.convert_pdf_to_mp3")
     def test_cli_no_progress_flag(self, mock_convert):
         """Test that --no-progress flag disables progress."""
         with patch.object(sys, 'argv', ['pdf2mp3', str(self.dummy_pdf_path), '--no-progress']):


### PR DESCRIPTION
Removed the --quiet command-line option from src/pdf2mp3/cli.py and its corresponding test from tests/test_cli_unittest.py.

Also removed a duplicated section of help text from README.md.