### PR TITLE
Test: Add comprehensive CLI tests and refactor cli.py

### DIFF
--- a/src/pdf2mp3/cli.py
+++ b/src/pdf2mp3/cli.py
@@ -1,24 +1,22 @@
 import argparse
 from pathlib import Path
 import sys
-from . import core
+# Import core lazily to improve CLI startup speed
+# from . import core # This line is commented out
 from . import __version__ as package_version
 
 def main():
     """
     Command-Line Interface for pdf2mp3.
-
-    Parses command-line arguments and calls the core conversion function.
-    Handles argument validation and provides user feedback.
     """
     parser = argparse.ArgumentParser(
-        prog="pdf2mp3", # Explicitly set program name for help messages
+        prog="pdf2mp3",
         description="Convert a PDF e-book to a single MP3 file using Kokoro TTS.",
-        formatter_class=argparse.RawTextHelpFormatter, # Preserves formatting in help text
+        formatter_class=argparse.RawTextHelpFormatter,
         epilog="For more information, see README.md or visit the project repository."
     )
 
-    # --- Positional Arguments ---
+    # Positional Arguments
     parser.add_argument(
         "input_pdf",
         type=Path,
@@ -27,24 +25,24 @@ def main():
     parser.add_argument(
         "output_mp3",
         type=Path,
-        nargs='?', # Optional
+        nargs='?',
         help="Optional destination file path for the MP3.\n"
              "Defaults to the input PDF's basename with an '.mp3' extension "
              "in the current working directory."
     )
 
-    # --- Core Synthesis Options ---
+    # Core Synthesis Options
     synthesis_group = parser.add_argument_group("CORE SYNTHESIS OPTIONS")
     synthesis_group.add_argument(
         "-l", "--lang",
         type=str,
-        default="b", # Default to British English code
+        default="b",
         help="Target language code (e.g., 'a' for American English, 'b' for British English).\nRefer to README.md for the full list of supported codes.\nDefault: 'b' (British English)"
     )
     synthesis_group.add_argument(
         "-v", "--voice",
         type=str,
-        default="bf_emma", # Default from README
+        default="bf_emma",
         help="Voice preset. Refer to README.md for available voices.\nDefault: bf_emma"
     )
     synthesis_group.add_argument(
@@ -59,36 +57,34 @@ def main():
         default=r'[.”]\s*\n',
         help="Regular-expression pattern used to split extracted text from the PDF "
              "into smaller chunks for TTS processing.\n"
-             "Default: '[.”]\\s*\\n' (splits after periods or quotation marks "
-             "followed by optional whitespace and a newline)."
+             "Default: '[.”]\\s*\\n'"
     )
 
-    # --- Audio Encoding Options ---
+    # Audio Encoding Options
     audio_group = parser.add_argument_group("AUDIO ENCODING OPTIONS")
     audio_group.add_argument(
         "--bitrate",
         choices=['CONSTANT', 'VARIABLE'],
-        type=str.upper, # Convert to uppercase for easier comparison
+        type=str.upper,
         default='CONSTANT',
         help="MP3 bitrate control mode.\n  CONSTANT – fixed (CBR) [default]\n  VARIABLE – VBR (average bitrate)"
     )
     audio_group.add_argument(
-        "--compression", # Renamed from --compression-float to be more user-friendly
+        "--compression",
         type=float,
         default=0.5,
         help="Compression level (0.0 to 1.0).\n"
-             "Higher values generally result in smaller file sizes (lower bitrate/quality).\n"
-             "Lower values aim for better fidelity (higher bitrate/quality).\n"
-             "Actual effect depends on the --bitrate mode (CONSTANT or VARIABLE).\n"
+             "Higher values generally result in smaller file sizes.\n"
+             "Lower values aim for better fidelity.\n"
              "Default: 0.5"
     )
 
-    # --- Runtime and I/O Options ---
+    # Runtime and I/O Options
     runtime_group = parser.add_argument_group("RUNTIME AND I/O OPTIONS")
     runtime_group.add_argument(
         "--device",
         type=str,
-        default=None, # core.py will auto-detect
+        default=None,
         help="Compute device: cpu, cuda, cuda:0, …\nAuto-detected if omitted."
     )
     runtime_group.add_argument(
@@ -99,23 +95,23 @@ def main():
     runtime_group.add_argument(
         "--resume",
         action="store_true",
-        help="Continue a previously interrupted run by reusing\nthe temporary workspace of chunk files."
+        help="Continue a previously interrupted run by reusing temporary chunk files."
     )
     runtime_group.add_argument(
         "--tmp-dir",
         type=Path,
         default=None,
-        help="Directory for temporary chunk storage\n(default: “.<output-stem>_chunks” beside OUTPUT)."
+        help="Directory for temporary chunk storage (default: “.<output-stem>_chunks”)."
     )
     runtime_group.add_argument(
         "--no-progress",
-        action="store_false", # Becomes False if flag is present
-        dest="show_progress", # Store in 'show_progress'
-        default=True, # Default is to show progress
-        help="Disable the live progress bar during audio synthesis."
+        action="store_false",
+        dest="show_progress",
+        default=True,
+        help="Disable the live progress bar."
     )
 
-    # --- Miscellaneous Options ---
+    # Miscellaneous Options
     misc_group = parser.add_argument_group("MISCELLANEOUS OPTIONS")
     misc_group.add_argument(
         "--version",
@@ -123,36 +119,28 @@ def main():
         version=f"%(prog)s {package_version}",
         help="Show program's version number and exit."
     )
-    # argparse automatically adds --help
+    # argparse implicitly adds --help
 
     args = parser.parse_args()
 
-    # --- Argument Post-processing and Validation ---
-
-    # Determine output MP3 path if not explicitly provided
+    # Argument Post-processing and Validation
     output_mp3_path = args.output_mp3
     if output_mp3_path is None:
-        # Default to same name as input PDF but with .mp3 extension, in current dir
         output_mp3_path = Path.cwd() / (args.input_pdf.stem + ".mp3")
 
-
-    # Validate input PDF file existence
     if not args.input_pdf.is_file():
         parser.error(f"Input PDF file not found: {args.input_pdf}")
 
-    # Validate speed range
     if not (0.5 <= args.speed <= 2.0):
         parser.error(f"Speed must be between 0.5 and 2.0. Got: {args.speed}")
 
-    # Validate compression level range
     if not (0.0 <= args.compression <= 1.0):
         parser.error(f"Compression level must be between 0.0 and 1.0. Got: {args.compression}")
 
-    # Adjust show_progress if quiet mode is enabled
-    show_progress_actual = args.show_progress
-
-    # --- Call Core Conversion Logic ---
+    # Call Core Conversion Logic
     try:
+        # Import core here to make CLI startup faster when not converting
+        from . import core # core is imported here now
         core.convert_pdf_to_mp3(
             pdf_path=args.input_pdf,
             output_mp3_path=output_mp3_path,
@@ -160,22 +148,19 @@ def main():
             voice=args.voice,
             speed=args.speed,
             split_pattern=args.split_pattern,
-            bitrate_mode=args.bitrate, # Pass the renamed arg
-            compression_level=args.compression, # Pass the renamed arg
+            bitrate_mode=args.bitrate,
+            compression_level=args.compression,
             device=args.device,
             tmp_dir=args.tmp_dir,
             resume=args.resume,
-            show_progress=show_progress_actual, # Use potentially modified value
+            show_progress=args.show_progress,
             overwrite=args.overwrite,
-            # Note: The 'quiet' flag itself is not directly passed to core.
-            # Instead, its effect (like disabling progress bar) is handled here.
-            # Core functions should ideally use a logging setup if granular
-            # silence is needed there, or accept a 'verbose'/'quiet' flag.
-            # For now, core prints essential info/errors.
         )
+    except ImportError:
+        print("Error: Could not import the 'core' module. Ensure all dependencies, including torch and TTS, are installed correctly.", file=sys.stderr)
+        sys.exit(1)
     except Exception as e:
-        # Catch-all for unexpected errors during core processing
-        print(f"An unexpected error occurred: {e}", file=sys.stderr)
+        print(f"An unexpected error occurred during conversion: {e}", file=sys.stderr)
         sys.exit(1)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,354 @@
+"""Tests for the pdf2mp3.cli module."""
+
+import pytest
+from pathlib import Path
+import subprocess
+from unittest import mock
+import sys
+
+# Attempt to import main from cli, skip if it causes ImportError due to missing dependencies during test collection
+try:
+    from pdf2mp3 import cli
+except ImportError:
+    cli = None
+
+# Helper to get package version
+def get_package_version():
+    try:
+        from pdf2mp3 import __version__ as v
+        return v
+    except ImportError:
+        return "0.0.0" # Fallback
+
+PKG_VERSION = get_package_version()
+
+# Skip all tests in this module if cli could not be imported
+pytestmark = pytest.mark.skipif(cli is None, reason="CLI module (or its dependencies like torch/TTS) not available for testing.")
+
+@pytest.fixture
+def mock_args(tmp_path, monkeypatch):
+    """Fixture to mock sys.argv for testing argparse."""
+    def _mock_args(arg_list):
+        # Prepend program name (can be anything, as argparse ignores it)
+        full_args = ["pdf2mp3_test"] + arg_list
+        monkeypatch.setattr(sys, "argv", full_args)
+    return _mock_args
+
+@pytest.fixture
+def dummy_pdf(tmp_path):
+    """Creates a dummy PDF file for testing purposes."""
+    pdf_path = tmp_path / "test_document.pdf"
+    pdf_path.write_text("This is a dummy PDF content.")
+    return pdf_path
+
+@pytest.fixture
+def mock_convert_pdf_to_mp3(monkeypatch):
+    """Mocks the core.convert_pdf_to_mp3 function by replacing the core module in sys.modules."""
+    mock_converter_function = mock.Mock(name="convert_pdf_to_mp3_mock_function")
+
+    # Create a mock core module object
+    mock_core_module = mock.MagicMock(name="mock_core_module")
+    mock_core_module.convert_pdf_to_mp3 = mock_converter_function
+
+    # Before cli.main() is called (which contains the lazy 'from . import core'),
+    # we insert our mock_core_module into sys.modules.
+    # The key 'pdf2mp3.core' must match what the import system will look for.
+    # When 'from . import core' is executed within 'pdf2mp3.cli', it should find this mock.
+    monkeypatch.setitem(sys.modules, "pdf2mp3.core", mock_core_module)
+
+    return mock_converter_function # Return the mock function itself for assertions
+
+def run_cli_main_with_args(arg_list, monkeypatch):
+    """Helper to run cli.main() with specified args and catch SystemExit."""
+    # The first element of sys.argv is the program name. argparse uses this for help messages
+    # if 'prog' is not set in ArgumentParser. Here, 'prog' is set to 'pdf2mp3'.
+    # So, this first element "pdf2mp3_test_runner" doesn't affect the help output prog name.
+    full_args = ["pdf2mp3_test_runner"] + arg_list
+    monkeypatch.setattr(sys, "argv", full_args)
+    try:
+        cli.main()
+    except SystemExit as e:
+        return e.code # Return exit code
+    return 0 # Default exit code for success
+
+# --- Test Cases ---
+
+def test_cli_invoked_no_args_shows_help(capsys, monkeypatch):
+    """Test that invoking with no arguments shows help and exits."""
+    # argparse by default prints help to stderr if required args are missing
+    exit_code = run_cli_main_with_args([], monkeypatch)
+    assert exit_code != 0 # Should exit with error due to missing arg
+    captured = capsys.readouterr()
+    assert "usage: pdf2mp3 [-h]" in captured.err # Actual prog name is 'pdf2mp3'
+    assert "input_pdf" in captured.err # Missing required argument
+
+def test_cli_version(capsys, monkeypatch):
+    """Test the --version flag."""
+    exit_code = run_cli_main_with_args(["--version"], monkeypatch)
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert f"pdf2mp3 {PKG_VERSION}" in captured.out # Actual prog name is 'pdf2mp3'
+
+def test_cli_help(capsys, monkeypatch):
+    """Test the --help flag."""
+    exit_code = run_cli_main_with_args(["--help"], monkeypatch)
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "usage: pdf2mp3 [-h]" in captured.out # Actual prog name is 'pdf2mp3'
+    assert "Convert a PDF e-book to a single MP3 file" in captured.out
+
+def test_input_pdf_required(dummy_pdf, mock_convert_pdf_to_mp3, mock_args):
+    """Test that input_pdf is correctly passed."""
+    mock_args([str(dummy_pdf)])
+    cli.main()
+    mock_convert_pdf_to_mp3.assert_called_once()
+    call_args = mock_convert_pdf_to_mp3.call_args[1]
+    assert call_args['pdf_path'] == dummy_pdf
+
+def test_output_mp3_optional_default(dummy_pdf, mock_convert_pdf_to_mp3, mock_args):
+    """Test default output_mp3 path."""
+    mock_args([str(dummy_pdf)])
+    cli.main()
+    expected_output_path = Path.cwd() / (dummy_pdf.stem + ".mp3")
+    mock_convert_pdf_to_mp3.assert_called_once()
+    call_args = mock_convert_pdf_to_mp3.call_args[1]
+    assert call_args['output_mp3_path'] == expected_output_path
+
+def test_output_mp3_custom(dummy_pdf, tmp_path, mock_convert_pdf_to_mp3, mock_args):
+    """Test custom output_mp3 path."""
+    custom_output = tmp_path / "custom_audio.mp3"
+    mock_args([str(dummy_pdf), str(custom_output)])
+    cli.main()
+    mock_convert_pdf_to_mp3.assert_called_once()
+    call_args = mock_convert_pdf_to_mp3.call_args[1]
+    assert call_args['output_mp3_path'] == custom_output
+
+# Test Core Synthesis Options
+def test_lang_option(dummy_pdf, mock_convert_pdf_to_mp3, mock_args):
+    mock_args([str(dummy_pdf), "--lang", "a"])
+    cli.main()
+    mock_convert_pdf_to_mp3.assert_called_once()
+    assert mock_convert_pdf_to_mp3.call_args[1]['lang'] == "a"
+
+def test_voice_option(dummy_pdf, mock_convert_pdf_to_mp3, mock_args):
+    mock_args([str(dummy_pdf), "--voice", "test_voice"])
+    cli.main()
+    mock_convert_pdf_to_mp3.assert_called_once()
+    assert mock_convert_pdf_to_mp3.call_args[1]['voice'] == "test_voice"
+
+def test_speed_option_valid(dummy_pdf, mock_convert_pdf_to_mp3, mock_args):
+    mock_args([str(dummy_pdf), "--speed", "1.5"])
+    cli.main()
+    mock_convert_pdf_to_mp3.assert_called_once()
+    assert mock_convert_pdf_to_mp3.call_args[1]['speed'] == 1.5
+
+def test_speed_option_invalid_low(dummy_pdf, capsys, monkeypatch):
+    exit_code = run_cli_main_with_args([str(dummy_pdf), "--speed", "0.4"], monkeypatch)
+    assert exit_code != 0
+    captured = capsys.readouterr()
+    assert "Speed must be between 0.5 and 2.0" in captured.err
+
+def test_speed_option_invalid_high(dummy_pdf, capsys, monkeypatch):
+    exit_code = run_cli_main_with_args([str(dummy_pdf), "--speed", "2.1"], monkeypatch)
+    assert exit_code != 0
+    captured = capsys.readouterr()
+    assert "Speed must be between 0.5 and 2.0" in captured.err
+
+def test_split_pattern_option(dummy_pdf, mock_convert_pdf_to_mp3, mock_args):
+    mock_args([str(dummy_pdf), "--split-pattern", "\\n\\n"])
+    cli.main()
+    mock_convert_pdf_to_mp3.assert_called_once()
+    assert mock_convert_pdf_to_mp3.call_args[1]['split_pattern'] == "\\n\\n"
+
+# Test Audio Encoding Options
+def test_bitrate_option(dummy_pdf, mock_convert_pdf_to_mp3, mock_args):
+    mock_args([str(dummy_pdf), "--bitrate", "VARIABLE"])
+    cli.main()
+    mock_convert_pdf_to_mp3.assert_called_once()
+    assert mock_convert_pdf_to_mp3.call_args[1]['bitrate_mode'] == "VARIABLE"
+
+def test_compression_option_valid(dummy_pdf, mock_convert_pdf_to_mp3, mock_args):
+    mock_args([str(dummy_pdf), "--compression", "0.7"])
+    cli.main()
+    mock_convert_pdf_to_mp3.assert_called_once()
+    assert mock_convert_pdf_to_mp3.call_args[1]['compression_level'] == 0.7
+
+def test_compression_option_invalid_low(dummy_pdf, capsys, monkeypatch):
+    exit_code = run_cli_main_with_args([str(dummy_pdf), "--compression", "-0.1"], monkeypatch)
+    assert exit_code != 0
+    captured = capsys.readouterr()
+    assert "Compression level must be between 0.0 and 1.0" in captured.err
+
+def test_compression_option_invalid_high(dummy_pdf, capsys, monkeypatch):
+    exit_code = run_cli_main_with_args([str(dummy_pdf), "--compression", "1.1"], monkeypatch)
+    assert exit_code != 0
+    captured = capsys.readouterr()
+    assert "Compression level must be between 0.0 and 1.0" in captured.err
+
+# Test Runtime and I/O Options
+def test_device_option(dummy_pdf, mock_convert_pdf_to_mp3, mock_args):
+    mock_args([str(dummy_pdf), "--device", "cuda:1"])
+    cli.main()
+    mock_convert_pdf_to_mp3.assert_called_once()
+    assert mock_convert_pdf_to_mp3.call_args[1]['device'] == "cuda:1"
+
+def test_overwrite_option(dummy_pdf, mock_convert_pdf_to_mp3, mock_args):
+    mock_args([str(dummy_pdf), "--overwrite"])
+    cli.main()
+    mock_convert_pdf_to_mp3.assert_called_once()
+    assert mock_convert_pdf_to_mp3.call_args[1]['overwrite'] is True
+
+def test_resume_option(dummy_pdf, mock_convert_pdf_to_mp3, mock_args):
+    mock_args([str(dummy_pdf), "--resume"])
+    cli.main()
+    mock_convert_pdf_to_mp3.assert_called_once()
+    assert mock_convert_pdf_to_mp3.call_args[1]['resume'] is True
+
+def test_tmp_dir_option(dummy_pdf, tmp_path, mock_convert_pdf_to_mp3, mock_args):
+    custom_tmp_dir = tmp_path / "custom_tmp"
+    mock_args([str(dummy_pdf), "--tmp-dir", str(custom_tmp_dir)])
+    cli.main()
+    mock_convert_pdf_to_mp3.assert_called_once()
+    assert mock_convert_pdf_to_mp3.call_args[1]['tmp_dir'] == custom_tmp_dir
+
+def test_no_progress_option(dummy_pdf, mock_convert_pdf_to_mp3, mock_args):
+    mock_args([str(dummy_pdf), "--no-progress"])
+    cli.main()
+    mock_convert_pdf_to_mp3.assert_called_once()
+    assert mock_convert_pdf_to_mp3.call_args[1]['show_progress'] is False
+
+def test_default_progress_option(dummy_pdf, mock_convert_pdf_to_mp3, mock_args):
+    """Test that progress is shown by default."""
+    mock_args([str(dummy_pdf)])
+    cli.main()
+    mock_convert_pdf_to_mp3.assert_called_once()
+    assert mock_convert_pdf_to_mp3.call_args[1]['show_progress'] is True
+
+# Test Argument Validation
+def test_input_pdf_non_existent(tmp_path, capsys, monkeypatch):
+    non_existent_pdf = tmp_path / "does_not_exist.pdf"
+    exit_code = run_cli_main_with_args([str(non_existent_pdf)], monkeypatch)
+    assert exit_code != 0
+    captured = capsys.readouterr()
+    assert f"Input PDF file not found: {non_existent_pdf}" in captured.err
+
+# Note: Corrected to use the mock_convert_pdf_to_mp3 fixture properly.
+def test_core_convert_exception_handling(dummy_pdf, mock_args, monkeypatch, capsys, mock_convert_pdf_to_mp3):
+    """Test that exceptions from core.convert_pdf_to_mp3 are caught and handled."""
+    # mock_convert_pdf_to_mp3 is the mock function provided by the fixture.
+    # Configure its side_effect for this specific test.
+    mock_convert_pdf_to_mp3.side_effect = Exception("Core processing failed!")
+
+    # mock_args is used by run_cli_main_with_args implicitly through monkeypatch if not passed explicitly to cli.main
+    # We need to ensure sys.argv is set up by mock_args before calling run_cli_main_with_args,
+    # or rely on run_cli_main_with_args's internal monkeypatching.
+    # The current run_cli_main_with_args handles monkeypatching sys.argv itself.
+
+    exit_code = run_cli_main_with_args([str(dummy_pdf)], monkeypatch)
+
+    assert exit_code == 1 # Should exit with 1 on error
+    captured = capsys.readouterr()
+    assert "An unexpected error occurred during conversion: Core processing failed!" in captured.err
+    mock_convert_pdf_to_mp3.assert_called_once() # Assert on the correct mock
+
+def test_core_import_error_handling(dummy_pdf, mock_args, monkeypatch, capsys):
+    """Test that ImportError for the core module is handled."""
+
+    # To simulate an ImportError for 'from . import core' within cli.main,
+    # we can make 'pdf2mp3.core' temporarily un-importable.
+    # This is a bit tricky. One way is to ensure 'pdf2mp3.core' is not in sys.modules
+    # and that trying to import it fails.
+    # For this test, we'll simulate that 'from . import core' fails.
+    # The most robust way to do this is to make 'pdf2mp3.core' un-importable
+    # by monkeypatching __import__ or by removing 'pdf2mp3.core' from sys.modules
+    # and ensuring it cannot be found.
+
+    # We will use monkeypatch to temporarily replace the __import__ built-in
+    original_import = __builtins__["__import__"] # Store the original
+
+    def mocked_import(name, globals_dict=None, locals_dict=None, fromlist=(), level=0):
+        # Check if the import is for 'core' relative to 'pdf2mp3.cli'
+        # The `name` will be 'core', `fromlist` will be non-empty, and `level` will be 1 for 'from . import core'
+        # `globals_dict['__name__']` should be 'pdf2mp3.cli'
+        if name == "core" and globals_dict and globals_dict.get("__name__") == "pdf2mp3.cli" and level == 1:
+            raise ImportError("Simulated core import error for test")
+        elif name == "pdf2mp3.core": # Also catch direct import if that path is taken
+             raise ImportError("Simulated core import error for test")
+        return original_import(name, globals_dict, locals_dict, fromlist, level)
+
+    # Patch the __import__ in the 'builtins' module
+    monkeypatch.setattr(sys.modules['builtins'], "__import__", mocked_import)
+
+    # It's also good practice to ensure that pdf2mp3.core is not already in sys.modules from a previous import.
+    # The mock_convert_pdf_to_mp3 fixture might put a mock there, so we ensure it's removed
+    # for this specific test if we want to test the ImportError path cleanly.
+    if "pdf2mp3.core" in sys.modules:
+        monkeypatch.delitem(sys.modules, "pdf2mp3.core", raising=False)
+
+    exit_code = run_cli_main_with_args([str(dummy_pdf)], monkeypatch)
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Error: Could not import the 'core' module." in captured.err
+
+# It might be good to also test default values for all options
+# if they are not explicitly tested by being passed to the mock.
+# The mock_convert_pdf_to_mp3.call_args[1] contains all keyword args,
+# so we can check their default values there if not specified.
+
+def test_all_defaults_passed_to_core(dummy_pdf, mock_convert_pdf_to_mp3, mock_args):
+    """Test that all arguments have correct default values passed to core function."""
+    mock_args([str(dummy_pdf)])
+    cli.main()
+
+    mock_convert_pdf_to_mp3.assert_called_once()
+    kwargs = mock_convert_pdf_to_mp3.call_args[1]
+
+    assert kwargs['pdf_path'] == dummy_pdf
+    assert kwargs['output_mp3_path'] == Path.cwd() / (dummy_pdf.stem + ".mp3")
+    assert kwargs['lang'] == "b"
+    assert kwargs['voice'] == "bf_emma"
+    assert kwargs['speed'] == 0.8
+    assert kwargs['split_pattern'] == r'[.”]\s*\n'
+    assert kwargs['bitrate_mode'] == 'CONSTANT'
+    assert kwargs['compression_level'] == 0.5
+    assert kwargs['device'] is None # core.py handles auto-detect
+    assert kwargs['tmp_dir'] is None # core.py handles default
+    assert kwargs['resume'] is False
+    assert kwargs['show_progress'] is True
+    assert kwargs['overwrite'] is False
+
+# Example of how to use subprocess for a very basic CLI invocation test
+# This is more of an integration test and might be slower / more complex to set up.
+# For unit testing argument parsing, mocking sys.argv and calling main() is usually sufficient.
+# @pytest.mark.skip(reason="Subprocess tests are more like integration tests, slower")
+# def test_cli_with_subprocess_version():
+# """Test CLI invocation via subprocess for --version."""
+# This requires the package to be installed or python -m pdf2mp3.cli to work
+# result = subprocess.run([sys.executable, "-m", "pdf2mp3.cli", "--version"], capture_output=True, text=True)
+# assert result.returncode == 0
+# assert f"pdf2mp3 {PKG_VERSION}" in result.stdout
+#
+# @pytest.mark.skip(reason="Subprocess tests are more like integration tests, slower")
+# def test_cli_with_subprocess_help():
+# """Test CLI invocation via subprocess for --help."""
+# result = subprocess.run([sys.executable, "-m", "pdf2mp3.cli", "--help"], capture_output=True, text=True)
+# assert result.returncode == 0
+# assert "usage: cli.py [-h]" in result.stdout # Note: prog name might be cli.py
+# assert "Convert a PDF e-book" in result.stdout
+
+# Final check: ensure cli.main is callable if not skipped
+if cli is not None:
+    assert callable(cli.main)
+
+# TODO: Consider tests for interactions, e.g., --resume without a tmp_dir,
+# or --overwrite with an existing file (though this is more core logic behavior).
+# For CLI tests, we mostly care that the flag is correctly parsed and passed.
+
+# TODO: Test for invalid choices for arguments with 'choices' like --bitrate
+def test_bitrate_option_invalid_choice(dummy_pdf, capsys, monkeypatch):
+    exit_code = run_cli_main_with_args([str(dummy_pdf), "--bitrate", "INVALID_CHOICE"], monkeypatch)
+    assert exit_code != 0
+    captured = capsys.readouterr()
+    assert "invalid choice: 'INVALID_CHOICE'" in captured.err # argparse default error
+    assert "(choose from 'CONSTANT', 'VARIABLE')" in captured.err


### PR DESCRIPTION
- Add extensive pytest tests for src/pdf2mp3/cli.py, covering all arguments, options, and error handling scenarios.
- Mock core.convert_pdf_to_mp3 to isolate CLI logic for testing.
- Refactor src/pdf2mp3/cli.py:
  - Remove redundant comments.
  - Implement lazy loading for the `core` module to improve CLI startup speed when full conversion is not invoked (e.g., for --help or --version).