### PR TITLE
Fix: Adjust pipeline unpacking for kokoro API change

### DIFF
--- a/src/pdf2mp3/core.py
+++ b/src/pdf2mp3/core.py
@@ -223,8 +223,11 @@ def convert_pdf_to_mp3(
             continue
 
         try:
-            # Kokoro pipeline returns: (processed_text, voice_used, lang_used, audio_data)
-            _, _, _, audio_data = pipeline(
+            # Kokoro pipeline now expected to return 2 values.
+            # Assuming the second value is audio_data.
+            # The first value might be a tuple of (processed_text, voice_used, lang_used) or just processed_text.
+            # As these are currently discarded with '_', we'll assign it to a single underscore.
+            _, audio_data = pipeline(
                 text_chunk,
                 voice=voice,
                 speed=speed,


### PR DESCRIPTION
The pipeline call from the kokoro library was returning 2 values instead of the expected 4, causing an unpacking ValueError.

This change adjusts the unpacking to expect 2 values, assigning the second value to audio_data and discarding the first. This resolves the error based on the observed behavior.